### PR TITLE
Fix path prepending bug in functions.ps1

### DIFF
--- a/powershell-scripts/functions.ps1
+++ b/powershell-scripts/functions.ps1
@@ -207,7 +207,7 @@ function Set-Environment([String] $variable, [String] $value) {
 }
 
 # Add a folder to $env:Path
-function Prepend-EnvPath([String]$path) { $env:PATH = $env:PATH + ";$path" }
+function Prepend-EnvPath([String]$path) { $env:PATH = "$path;$env:PATH" }
 function Prepend-EnvPathIfExists([String]$path) { if (Test-Path $path) { Prepend-EnvPath $path } }
 function Append-EnvPath([String]$path) { $env:PATH = $env:PATH + ";$path" }
 function Append-EnvPathIfExists([String]$path) { if (Test-Path $path) { Append-EnvPath $path } }


### PR DESCRIPTION
## Summary
- fix Prepend-EnvPath to actually prepend paths

## Testing
- `pwsh -c "Write-Host 'test'"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68437a92de08832f8aa535ca8e230d6c