### PR TITLE
Fix Prepend-EnvPath formatting

### DIFF
--- a/powershell-scripts/functions.ps1
+++ b/powershell-scripts/functions.ps1
@@ -207,8 +207,12 @@ function Set-Environment([String] $variable, [String] $value) {
 }
 
 # Add a folder to $env:Path
-function Prepend-EnvPath([String]$path) { $env:PATH = "$path;$env:PATH" }
-function Prepend-EnvPathIfExists([String]$path) { if (Test-Path $path) { Prepend-EnvPath $path } }
+function Prepend-EnvPath([String] $path) {
+    $env:PATH = "$path;$env:PATH"
+}
+function Prepend-EnvPathIfExists([String] $path) {
+    if (Test-Path $path) { Prepend-EnvPath $path }
+}
 function Append-EnvPath([String]$path) { $env:PATH = $env:PATH + ";$path" }
 function Append-EnvPathIfExists([String]$path) { if (Test-Path $path) { Append-EnvPath $path } }
 


### PR DESCRIPTION
## Summary
- tidy the Prepend-EnvPath function

## Testing
- `pwsh -NoProfile -Command "& { . ./powershell-scripts/functions.ps1 }"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68437d0feaa4832fb47840324fbd432a