### PR TITLE
Add Pester tests for env path helpers

### DIFF
--- a/tests/Functions.Tests.ps1
+++ b/tests/Functions.Tests.ps1
@@ -1,0 +1,28 @@
+Describe 'EnvPath functions' {
+    BeforeAll {
+        $script:originalPath = $env:PATH
+        . "$PSScriptRoot/../powershell-scripts/functions.ps1"
+    }
+    BeforeEach {
+        $env:PATH = $script:originalPath
+    }
+    AfterAll {
+        $env:PATH = $script:originalPath
+    }
+
+    Context 'Prepend-EnvPath' {
+        It 'places a path at the start of $env:PATH' {
+            $env:PATH = 'C:\Existing1;C:\Existing2'
+            Prepend-EnvPath 'C:\Start'
+            $env:PATH | Should -Be 'C:\Start;C:\Existing1;C:\Existing2'
+        }
+    }
+
+    Context 'Append-EnvPath' {
+        It 'places a path at the end of $env:PATH' {
+            $env:PATH = 'C:\Existing1;C:\Existing2'
+            Append-EnvPath 'C:\End'
+            $env:PATH | Should -Be 'C:\Existing1;C:\Existing2;C:\End'
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `tests/Functions.Tests.ps1` with Pester tests for `Prepend-EnvPath` and `Append-EnvPath`

## Testing
- `pwsh -NoLogo -Command 'Invoke-Pester -Script ./tests/Functions.Tests.ps1 -PassThru'` *(fails: Invoke-Pester not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_6843855ac974832fac8a5cdf20ab761c