### PR TITLE
Fix spelling of productivitytools

### DIFF
--- a/dotfiles-configurations/dotfiles-bootstrap-variables.json
+++ b/dotfiles-configurations/dotfiles-bootstrap-variables.json
@@ -21,7 +21,7 @@
         "docker",
         "pwsh",
         "developer",
-        "produtivitytools",
+        "productivitytools",
         "internetbrowser",
         "multimedia"
     ],


### PR DESCRIPTION
## Summary
- fix `productivitytools` spelling in bootstrap variables

## Testing
- `pwsh -NoProfile -Command "Invoke-Pester -Path tests"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685b3be28018832f8d9c6a1ec8956010