### PR TITLE
Update Get-DiskUsage to honor path parameter

### DIFF
--- a/powershell-scripts/functions.ps1
+++ b/powershell-scripts/functions.ps1
@@ -167,7 +167,7 @@ function CreateAndSet-Directory([String] $path) { New-Item $path -ItemType Direc
 function Get-DiskUsage([string] $path=(Get-Location).Path) {
     Convert-ToDiskSize `
         ( `
-            Get-ChildItem .\ -recurse -ErrorAction SilentlyContinue `
+            Get-ChildItem $path -Recurse -ErrorAction SilentlyContinue `
             | Measure-Object -property length -sum -ErrorAction SilentlyContinue
         ).Sum `
         1


### PR DESCRIPTION
## Summary
- ensure Get-DiskUsage uses its provided path

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y powershell` *(fails: Unable to locate package)*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685b3c143d38832fbff74ac07eaafa6b