### PR TITLE
Extend Unzip-File with ForceCOM option

### DIFF
--- a/powershell-scripts/functions.ps1
+++ b/powershell-scripts/functions.ps1
@@ -293,28 +293,39 @@ function Unzip-File {
         [string]$File,
 
         [ValidateNotNullOrEmpty()]
-        [string]$Destination = (Get-Location).Path
+        [string]$Destination = (Get-Location).Path,
+
+        [switch]$ForceCOM
     )
 
     $filePath = Resolve-Path $File
     $destinationPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Destination)
 
-    if (($PSVersionTable.PSVersion.Major -ge 3) -and
-       ((Get-ItemProperty -Path "HKLM:\Software\Microsoft\NET Framework Setup\NDP\v4\Full" -ErrorAction SilentlyContinue).Version -like "4.5*" -or
-       (Get-ItemProperty -Path "HKLM:\Software\Microsoft\NET Framework Setup\NDP\v4\Client" -ErrorAction SilentlyContinue).Version -like "4.5*")) {
-
-        try {
-            [System.Reflection.Assembly]::LoadWithPartialName("System.IO.Compression.FileSystem") | Out-Null
-            [System.IO.Compression.ZipFile]::ExtractToDirectory("$filePath", "$destinationPath")
-        } catch {
-            Write-Warning -Message "Unexpected Error. Error details: $_.Exception.Message"
-        }
-    } else {
+    if ($ForceCOM) {
         try {
             $shell = New-Object -ComObject Shell.Application
             $shell.Namespace($destinationPath).copyhere(($shell.NameSpace($filePath)).items())
         } catch {
             Write-Warning -Message "Unexpected Error. Error details: $_.Exception.Message"
+        }
+    } else {
+        if (($PSVersionTable.PSVersion.Major -ge 3) -and
+           ((Get-ItemProperty -Path "HKLM:\Software\Microsoft\NET Framework Setup\NDP\v4\Full" -ErrorAction SilentlyContinue).Version -like "4.5*" -or
+           (Get-ItemProperty -Path "HKLM:\Software\Microsoft\NET Framework Setup\NDP\v4\Client" -ErrorAction SilentlyContinue).Version -like "4.5*")) {
+
+            try {
+                [System.Reflection.Assembly]::LoadWithPartialName("System.IO.Compression.FileSystem") | Out-Null
+                [System.IO.Compression.ZipFile]::ExtractToDirectory("$filePath", "$destinationPath")
+            } catch {
+                Write-Warning -Message "Unexpected Error. Error details: $_.Exception.Message"
+            }
+        } else {
+            try {
+                $shell = New-Object -ComObject Shell.Application
+                $shell.Namespace($destinationPath).copyhere(($shell.NameSpace($filePath)).items())
+            } catch {
+                Write-Warning -Message "Unexpected Error. Error details: $_.Exception.Message"
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend `Unzip-File` to support a new switch parameter `ForceCOM`
- choose the COM extraction method when `ForceCOM` is specified

## Testing
- `powershell` and `pwsh` were not available so tests could not be run


------
https://chatgpt.com/codex/tasks/task_b_685b3d37bcdc832fa5631f54d2bb9309