### PR TITLE
Refactor: Create dedicated module for PowerShell profile symlink crea…

### DIFF
--- a/setup-modules/Create-PowerShellProfileSymlink.ps1
+++ b/setup-modules/Create-PowerShellProfileSymlink.ps1
@@ -1,0 +1,89 @@
+<#
+.SYNOPSIS
+Creates a symbolic link for the PowerShell profile.
+
+.DESCRIPTION
+This script creates a symbolic link from the user's profile directory to the custom profile directory specified in the dotfiles configuration.
+It handles cases where the destination already exists (either as a symlink or a directory) and ensures it runs with administrator privileges.
+
+.NOTES
+This script is intended to be run from the root of the dotfiles repository.
+#>
+
+# Assuming the script is run from the dotfiles repository root.
+$PSScriptRoot = Get-Location
+. "$PSScriptRoot\setup-scripts\setup-functions.ps1"
+
+# Variables for logging
+$dateTime = Get-Date -Format "yyyyMMdd-HHmmss"
+$logDir = Join-Path $PSScriptRoot "logs"
+$scriptName = "Create-PowerShellProfileSymlink"
+$logFile = "$logDir\$scriptName-$dateTime.txt"
+
+# Start logging
+Start-Logging -LogFilePath $logFile
+
+# Apply the dotfiles bootstrap variables
+Write-Info "Applying dotfiles bootstrap variables..."
+$bootstrapVariablesPath = Join-Path $PSScriptRoot "dotfiles-configurations\dotfiles-bootstrap-variables.json"
+$DotfilesVariables = Get-Content -Path $bootstrapVariablesPath | ConvertFrom-Json
+if (-not $DotfilesVariables) {
+    Write-WarningMessage "No dotfiles bootstrap variables found at '$bootstrapVariablesPath'."
+    Stop-Logging
+    Exit 1
+}
+
+# Validate required configuration values
+$requiredVars = @("CUSTOM_PROFILE_FOLDER")
+$missingVars = $requiredVars | Where-Object { -not $DotfilesVariables.$_ }
+
+if ($missingVars) {
+    Write-ErrorMessage "Missing required configuration variables: $($missingVars -join ', ')"
+    Stop-Logging
+    Exit 1
+}
+
+# Create a symbolic link to the custom profile directory
+Write-Info "Creating a symbolic link to the custom profile directory"
+$customProfileDirectory = Join-Path $env:USERPROFILE $DotfilesVariables.CUSTOM_PROFILE_FOLDER
+$profileDirectory = Split-Path -Parent $PROFILE
+
+# Create a symlink to the custom profile directory if it does not exist or is not a symlink
+$createSymlink = $false
+if (Test-Path $customProfileDirectory) {
+    $item = Get-Item $customProfileDirectory -Force
+    if ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) {
+        Write-Info "Custom profile directory already exists as a symlink: $customProfileDirectory"
+    } else {
+        Write-Info "Custom profile directory exists as a normal directory."
+        $userInput = Read-Host "Do you want to delete this directory and replace it with a symlink? (Y/N)"
+        if ($userInput -match '^(Y|y)') {
+            Write-Info "Removing directory..."
+            Remove-Item $customProfileDirectory -Recurse -Force
+            $createSymlink = $true
+        } else {
+            Write-WarningMessage "Symlink creation skipped. Directory was not removed."
+        }
+    }
+} else {
+    $createSymlink = $true
+}
+
+if ($createSymlink) {
+    Write-Info "Creating symbolic link to the custom profile directory: $customProfileDirectory"
+    try {
+        # Try to create a symbolic link
+        New-Item -ItemType SymbolicLink -Path $customProfileDirectory -Value $profileDirectory -Force -ErrorAction Stop | Out-Null
+        if (Test-Path $customProfileDirectory) {
+            Write-Info "Symbolic link to the custom profile directory created successfully"
+        } else {
+            throw "Unknown error: symlink not created"
+        }
+    } catch {
+        Write-ErrorMessage "Failed to create a symbolic link: $($_.Exception.Message)"
+        Stop-Logging
+        Exit 1
+    }
+}
+
+Stop-Logging

--- a/setup-scripts/setup.ps1
+++ b/setup-scripts/setup.ps1
@@ -71,69 +71,6 @@ if ($missingVars) {
     Exit 1
 }
 
-# Create a symbolic link to the custom profile directory
-Write-Info "Creating a symbolic link to the custom profile directory"
-$customProfileDirectory = Join-Path $env:USERPROFILE $DotfilesVariables.CUSTOM_PROFILE_FOLDER
-$profileDirectory = Split-Path -Parent $PROFILE
-
-# Create a symlink to the custom profile directory if it does not exist or is not a symlink
-$createSymlink = $false
-if (Test-Path $customProfileDirectory) {
-    $item = Get-Item $customProfileDirectory -Force
-    if ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) {
-        Write-Info "Custom profile directory already exists as a symlink: $customProfileDirectory"
-    } else {
-        Write-Info "Custom profile directory exists as a normal directory."
-        $userInput = Read-Host "Do you want to delete this directory and replace it with a symlink? (Y/N)"
-        if ($userInput -match '^(Y|y)') {
-            Write-Info "Removing directory..."
-            Remove-Item $customProfileDirectory -Recurse -Force
-            $createSymlink = $true
-        } else {
-            Write-WarningMessage "Symlink creation skipped. Directory was not removed."
-        }
-    }
-} else {
-    $createSymlink = $true
-}
-
-if ($createSymlink) {
-    #TODO: Replace this with a function that creates a symlink with error handling
-    Write-Info "Creating symbolic link to the custom profile directory: $customProfileDirectory"
-    # Check if running as administrator
-    $isAdmin = ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-    if (-not $isAdmin) {
-        Write-WarningMessage "Symlink creation requires elevated privileges. Relaunching this block as administrator..."
-        $symlinkScript = @"
-try {
-    New-Item -ItemType SymbolicLink -Path '$customProfileDirectory' -Value '$profileDirectory' -Force -ErrorAction Stop | Out-Null
-    if (Test-Path '$customProfileDirectory') {
-        Write-Host 'Symbolic link to the custom profile directory created successfully'
-    } else {
-        throw 'Unknown error: symlink not created'
-    }
-} catch {
-    Write-Warning "Failed to create a symbolic link: $($_.Exception.Message)"
-}
-"@
-        $tempScriptPath = [System.IO.Path]::GetTempFileName() + '.ps1'
-        Set-Content -Path $tempScriptPath -Value $symlinkScript -Encoding UTF8
-        Start-Process -FilePath 'pwsh.exe' -ArgumentList "-NoProfile -ExecutionPolicy Bypass -File `"$tempScriptPath`"" -Verb RunAs -Wait
-        Remove-Item $tempScriptPath -Force
-    } else {
-        try {
-            # Try to create a symbolic link
-            New-Item -ItemType SymbolicLink -Path $customProfileDirectory -Value $profileDirectory -Force -ErrorAction Stop | Out-Null
-            if (Test-Path $customProfileDirectory) {
-                Write-Info "Symbolic link to the custom profile directory created successfully"
-            } else {
-                throw "Unknown error: symlink not created"
-            }
-        } catch {
-            Write-WarningMessage "Failed to create a symbolic link: $($_.Exception.Message)"
-        }
-    }
-}
 
 # Create workspace directory if it does not exist
 Write-Info "Creating workspace directory"
@@ -173,13 +110,15 @@ $modulesToRun = @(
     "Configure-WindowsFeatures.ps1",
     "Install-WingetPackages.ps1",
     "Set-EnvironmentVariables.ps1",
-    "Apply-GitConfig.ps1"
+    "Apply-GitConfig.ps1",
+    "Create-PowerShellProfileSymlink.ps1"
 )
 
 # Modules that require administrator privileges
 $adminModules = @(
     "Configure-WindowsFeatures.ps1",
-    "Configure-HyperV+WSL.ps1"
+    "Configure-HyperV+WSL.ps1",
+    "Create-PowerShellProfileSymlink.ps1"
 )
 
 if (-not (Test-Path $moduleScriptsPath)) {


### PR DESCRIPTION
Refactor: Create dedicated module for PowerShell profile symlink creation

This commit refactors the `setup.ps1` script by extracting the logic for creating the PowerShell profile symbolic link into a new, self-contained module: `Create-PowerShellProfileSymlink.ps1`.